### PR TITLE
feat(tests): add `only` and `skip`, remove `modifier`

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ this will be `path.join`ed with the `fixtures` path.
 If you'd rather put your `output` in a separate file, you can specify this
 instead (works the same as `fixture`).
 
+#### only
+
+To run only this test. Useful while developing to help focus on a single test.
+Can be used on multiple tests.
+
+#### skip
+
+To skip running this test. Useful for when you're working on a feature that is
+not yet supported.
+
 #### snapshot
 
 If you'd prefer to take a snapshot of your output rather than compare it to

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -18,6 +18,8 @@ exports[`plugin is required 1`] = `"plugin is a required parameter."`;
 
 exports[`snapshot option can be derived from the root config 1`] = `"\`output\` cannot be provided with \`snapshot: true\`"`;
 
+exports[`tests cannot be both only-ed and skipped 1`] = `"Cannot enable both skip and only on a test"`;
+
 exports[`throws an invariant if the plugin name is not inferable 1`] = `"The \`pluginName\` must be inferable or provided."`;
 
 exports[`throws error if fixture provided and code changes 1`] = `"Expected output to not change, but it did"`;

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,8 @@ function pluginTester(
         return
       }
       const {
-        modifier,
+        skip,
+        only,
         title,
         code,
         babelOptions,
@@ -64,9 +65,17 @@ function pluginTester(
         testerConfig,
         toTestConfig({testConfig, index, plugin, pluginName, filename}),
       )
+      assert(
+        (!skip && !only) || skip !== only,
+        'Cannot enable both skip and only on a test',
+      )
 
-      if (modifier) {
-        it[modifier](title, tester)
+      if (skip) {
+        // eslint-disable-next-line jest/no-disabled-tests
+        it.skip(title, tester)
+      } else if (only) {
+        // eslint-disable-next-line jest/no-focused-tests
+        it.only(title, tester)
       } else {
         it(title, tester)
       }


### PR DESCRIPTION
This removes `modifier` in favor of `only` and `skip` which are more straightforward. `modifier` was never documented.

BREAKING CHANGE: `modifier` has been removed, use `only` and `skip` instead