### PR TITLE
Remove recast

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,8 @@ pluginTester({
   // these will be `lodash.merge`d with the test objects
   // below are the defaults:
   babelOptions: {
-    parserOpts: {parser: recast.parse},
-    generatorOpts: {generator: recast.print, lineTerminator: '\n'},
+    parserOpts: {},
+    generatorOpts: {},
     babelrc: false,
   },
   snapshot: false, // use jest snapshots (only works with jest)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "invariant": "^2.2.2",
     "lodash.merge": "^4.6.0",
     "path-exists": "^3.0.0",
-    "recast": "^0.12.3",
     "strip-indent": "^2.0.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ import fs from 'fs'
 import pathExists from 'path-exists'
 import merge from 'lodash.merge'
 import invariant from 'invariant'
-import * as recast from 'recast'
 import * as babel from 'babel-core'
 import stripIndent from 'strip-indent'
 import {oneLine} from 'common-tags'
@@ -13,8 +12,8 @@ module.exports = pluginTester
 
 const fullDefaultConfig = {
   babelOptions: {
-    parserOpts: {parser: recast.parse},
-    generatorOpts: {generator: recast.print, lineTerminator: '\n'},
+    parserOpts: {},
+    generatorOpts: {},
     babelrc: false,
   },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -280,10 +280,6 @@ ast-types-flow@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
 
-ast-types@0.9.11:
-  version "0.9.11"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.11.tgz#371177bb59232ff5ceaa1d09ee5cad705b1a5aa9"
-
 ast-types@0.9.8:
   version "0.9.8"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.8.tgz#6cb6a40beba31f49f20928e28439fc14a3dab078"
@@ -1418,7 +1414,7 @@ convert-source-map@^1.1.0, convert-source-map@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
-core-js@^2.4.0, core-js@^2.4.1:
+core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 
@@ -2030,7 +2026,7 @@ esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
-esprima@^3.1.1, esprima@~3.1.0:
+esprima@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
@@ -4525,7 +4521,7 @@ pretty-format@^20.0.1:
     ansi-regex "^2.1.1"
     ansi-styles "^3.0.0"
 
-private@^0.1.6, private@~0.1.5:
+private@^0.1.6:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
 
@@ -4679,16 +4675,6 @@ readline2@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     mute-stream "0.0.5"
-
-recast@^0.12.3:
-  version "0.12.3"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.12.3.tgz#ce39d41911ea56d69701216d61e350a4d9505d4d"
-  dependencies:
-    ast-types "0.9.11"
-    core-js "^2.4.1"
-    esprima "~3.1.0"
-    private "~0.1.5"
-    source-map "~0.5.0"
 
 rechoir@^0.6.2:
   version "0.6.2"
@@ -5121,7 +5107,7 @@ source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.0, source-map@~0.5.1, source-map@~0.5.3:
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 


### PR DESCRIPTION
I'm not sure why these were the default, but they cause Babel plugins to behave differently and to turn them off is difficult so I've just removed them.